### PR TITLE
feat(nix): add flake.nix for NixOS Neovim plugin integration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,9 +65,6 @@
           packages = with pkgs; [
             cargo
             rustc
-            rust-analyzer
-            clippy
-            rustfmt
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,10 +10,11 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        version = (builtins.fromTOML (builtins.readFile ./core/Cargo.toml)).package.version;
 
         jupynvim-core = pkgs.rustPlatform.buildRustPackage {
           pname = "jupynvim-core";
-          version = "0.1.0";
+          inherit version;
           src = ./core;
           cargoLock = {
             lockFile = ./core/Cargo.lock;
@@ -31,7 +32,7 @@
         #   <plugin_root>/core/target/release/jupynvim-core
         jupynvim = pkgs.vimUtils.buildVimPlugin {
           pname = "jupynvim";
-          version = "0.1.0";
+          inherit version;
           src = pkgs.lib.cleanSourceWith {
             src = ./.;
             # Only include runtime Lua files; Rust source and CI config are

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "jupynvim — Jupyter notebooks in Neovim with VSCode-style UX";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        jupynvim-core = pkgs.rustPlatform.buildRustPackage {
+          pname = "jupynvim-core";
+          version = "0.1.0";
+          src = ./core;
+          cargoLock = {
+            lockFile = ./core/Cargo.lock;
+          };
+          meta = with pkgs.lib; {
+            description = "Native backend for jupynvim";
+            homepage = "https://github.com/sheng-tse/jupynvim";
+            license = licenses.mit;
+            mainProgram = "jupynvim-core";
+          };
+        };
+
+        # Neovim plugin derivation: Lua files + binary symlinked at the path
+        # that lua/jupynvim/init.lua's locate_core() looks for:
+        #   <plugin_root>/core/target/release/jupynvim-core
+        jupynvim = pkgs.vimUtils.buildVimPlugin {
+          pname = "jupynvim";
+          version = "0.1.0";
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            # Only include runtime Lua files; Rust source and CI config are
+            # not needed in the plugin store path.
+            filter = path: type:
+              let rel = pkgs.lib.removePrefix (toString ./. + "/") path;
+              in !(pkgs.lib.hasPrefix "core" rel)
+                 && !(pkgs.lib.hasPrefix ".github" rel)
+                 && rel != "flake.nix"
+                 && rel != "flake.lock";
+          };
+          postInstall = ''
+            mkdir -p $out/core/target/release
+            ln -s ${jupynvim-core}/bin/jupynvim-core \
+              $out/core/target/release/jupynvim-core
+          '';
+          meta = with pkgs.lib; {
+            description = "Jupyter notebooks in Neovim with VSCode-style UX";
+            homepage = "https://github.com/sheng-tse/jupynvim";
+            license = licenses.mit;
+          };
+        };
+      in
+      {
+        packages = {
+          inherit jupynvim-core jupynvim;
+          default = jupynvim;
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            cargo
+            rustc
+            rust-analyzer
+            clippy
+            rustfmt
+          ];
+        };
+      }
+    ) // {
+      # Overlay to inject the packages into a nixpkgs instance.
+      # Add to nixpkgs.overlays and then reference as
+      #   pkgs.vimPlugins.jupynvim  or  pkgs.jupynvim-core
+      overlays.default = final: prev: {
+        jupynvim-core = self.packages.${final.system}.jupynvim-core;
+        vimPlugins = prev.vimPlugins // {
+          jupynvim = self.packages.${final.system}.jupynvim;
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` that builds the `jupynvim-core` Rust binary via `rustPlatform.buildRustPackage`
- The `vimUtils.buildVimPlugin` derivation symlinks the built binary into `core/target/release/jupynvim-core` in `postInstall`, so `locate_core()` finds it without any changes to the Lua source
- Expose `overlays.default` so the plugin can be injected into a nixpkgs instance as `pkgs.vimPlugins.jupynvim`

## Usage (NixOS)

```nix
{
  inputs.jupynvim.url = "github:sheng-tse/jupynvim";

  programs.neovim.plugins = [{
    plugin = jupynvim.packages.x86_64-linux.default;
    type = "lua";
    config = ''require("jupynvim").setup({})'';
  }];
}
```

Run `nix flake lock` on first use to generate `flake.lock`. Rust dependencies are resolved offline from `Cargo.lock` at build time, so no `cargo build` is needed at Neovim startup.

## Test plan

- [ ] `nix build .#jupynvim-core` builds the Rust binary successfully
- [ ] `nix build .` produces the Neovim plugin derivation
- [ ] `result/core/target/release/jupynvim-core` is an executable symlink pointing to the Nix store binary
- [ ] Notebooks open correctly when the plugin is wired into a NixOS Neovim configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)