### PR TITLE
Remove global conceallevel and concealcursor options

### DIFF
--- a/lua/jupynvim/init.lua
+++ b/lua/jupynvim/init.lua
@@ -1661,9 +1661,6 @@ function M.setup(opts)
     end)
   end
 
-  vim.opt.conceallevel = 2
-  vim.opt.concealcursor = "nc"
-
   -- Hijack .ipynb opens
   local group = vim.api.nvim_create_augroup("JupynvimDispatch", { clear = true })
   vim.api.nvim_create_autocmd("BufReadCmd", {


### PR DESCRIPTION
Remove global conceallevel and concealcursor settings from setup. These options affect unrelated buffers and can change user configuration unexpectedly, such as causing JSON quotes to be concealed.

Notebook buffers already configure conceal locally when opened by the plugin, so the global settings are unnecessary.