### PR TITLE
Drop deprecated neovim functions

### DIFF
--- a/lua/jupynvim/image.lua
+++ b/lua/jupynvim/image.lua
@@ -174,7 +174,7 @@ local function tty_write(s)
   M._tty_n = (M._tty_n or 0) + 1
   M._tty_bytes = (M._tty_bytes or 0) + #s
   if IN_TMUX then s = tmux_wrap(s) end
-  local uv = vim.uv or vim.loop
+  local uv = vim.uv
 
   -- 1) chansend(vim.v.stderr, ...) — this is what image.nvim uses. vim.v.stderr
   -- is a channel ID that always points at nvim's stderr stream, which the TUI
@@ -580,7 +580,7 @@ local function start_animation(p, cell_id)
       pcall(p.timer.start, p.timer, d, 0, vim.schedule_wrap(tick))
     end
   end
-  p.timer = vim.loop.new_timer()
+  p.timer = vim.uv.new_timer()
   pcall(p.timer.start, p.timer, p.delays[1] or 100, 0, vim.schedule_wrap(tick))
 end
 

--- a/lua/jupynvim/init.lua
+++ b/lua/jupynvim/init.lua
@@ -1192,12 +1192,12 @@ function M.open(path, opts)
   -- text to disk, breaking save. Neovim's vim.lsp.enable callback
   -- explicitly skips buftype != '' (runtime/lua/vim/lsp.lua: lsp_enable_callback)
   -- so we attach LSP manually below in M._attach_lsp.
-  vim.api.nvim_set_option_value("buftype", "acwrite", { buf = buf })
-  vim.api.nvim_buf_set_option(buf, "swapfile", false)
-  vim.api.nvim_buf_set_option(buf, "modifiable", true)
+  vim.bo[buf].buftype = "acwrite"
+  vim.bo[buf].swapfile = false
+  vim.bo[buf].modifiable = true
   -- List it so it shows in the bufferline as a tab, like the .py/.rs files the
   -- explorer opens via :edit (bufnr(abs, true) creates it UNLISTED otherwise).
-  vim.api.nvim_buf_set_option(buf, "buflisted", true)
+  vim.bo[buf].buflisted = true
   local ft = language_filetype(snap)
   vim.b[buf].jupynvim_filetype = ft
 
@@ -1602,13 +1602,13 @@ end
 
 function M._populate_buffer(nb)
   local lines = nb:to_lines()
-  vim.api.nvim_buf_set_option(nb.buf, "modifiable", true)
+  vim.bo[nb.buf].modifiable = true
   vim.api.nvim_buf_set_lines(nb.buf, 0, -1, false, lines)
-  vim.api.nvim_buf_set_option(nb.buf, "modified", false)
+  vim.bo[nb.buf].modified = false
   -- cell command mode keeps the buffer non-modifiable; restore the lock
   -- after this (possibly async) repopulation
   if require("jupynvim.cellmode").is_command(nb.buf) then
-    vim.api.nvim_buf_set_option(nb.buf, "modifiable", false)
+    vim.bo[nb.buf].modifiable = false
   end
   -- Pre-conceal cell separator marker lines synchronously, before the
   -- debounced Render.refresh runs. Without this, the literal
@@ -1852,7 +1852,7 @@ function M._attach_autocmds(buf)
         local current = vim.fn.sha256(
           table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n"))
         if current ~= nb.saved_hash then
-          pcall(vim.api.nvim_buf_set_option, buf, "modified", true)
+          pcall(vim.api.nvim_set_option_value, "modified", true, { buf = buf })
         end
       end
       -- Sync cell.source from buffer so render's content-driven filters
@@ -1892,7 +1892,7 @@ function M._attach_autocmds(buf)
         -- We just rewrote the buffer to swap a pasted data:URI with the
         -- short placeholder; that's a real edit, not a no-op. Keep the
         -- modified flag set so :wqa actually triggers BufWriteCmd.
-        pcall(vim.api.nvim_buf_set_option, buf, "modified", true)
+        pcall(vim.api.nvim_set_option_value, "modified", true, { buf = buf })
       end
       Render.refresh(nb, vim.fn.bufwinid(buf))
       M._sync_treesitter_ranges(nb)
@@ -2030,7 +2030,7 @@ function M._save(nb)
     return
   end
   if vim.api.nvim_buf_is_valid(nb.buf) then
-    vim.api.nvim_buf_set_option(nb.buf, "modified", false)
+    vim.bo[nb.buf].modified = false
     -- Refresh the saved-state hash so subsequent TextChanged checks compare
     -- against the post-save buffer text, not the pre-save one.
     nb.saved_hash = vim.fn.sha256(
@@ -2263,7 +2263,7 @@ function M.set_cell_type(buf, t)
   -- by hand or :wqa skips the buffer entirely.
   cell.cell_type = t
   if t ~= "code" then cell.outputs = {}; cell.execution_count = nil end
-  pcall(vim.api.nvim_buf_set_option, buf, "modified", true)
+  pcall(vim.api.nvim_set_option_value, "modified", true, { buf = buf })
   M._sync_treesitter_ranges(nb)
   Render.refresh(nb, vim.fn.bufwinid(buf))
   -- LSPs aren't notified of cell-type changes (no didChange fires - the

--- a/lua/jupynvim/init.lua
+++ b/lua/jupynvim/init.lua
@@ -673,12 +673,12 @@ function M.connect(alias)
             pcall(vim.api.nvim_buf_delete, term_buf, { force = true })
           end
           -- Poll briefly for master to appear (FSEvent race after fork).
-          local deadline = vim.loop.hrtime() + 3e9  -- 3 seconds
+          local deadline = vim.uv.hrtime() + 3e9  -- 3 seconds
           local function check()
             if master_alive(alias, profile) then
               vim.notify("jupynvim: " .. alias .. " connected", vim.log.levels.INFO)
               M.remote_browse(alias)
-            elseif vim.loop.hrtime() < deadline then
+            elseif vim.uv.hrtime() < deadline then
               vim.defer_fn(check, 200)
             else
               vim.notify("jupynvim: " .. alias .. " auth exited 0 but master not detected",

--- a/lua/jupynvim/notebook.lua
+++ b/lua/jupynvim/notebook.lua
@@ -249,7 +249,7 @@ function Notebook:sync_from_buffer()
     end
     for i = n_state + 1, n_buf do
       table.insert(self.cells, {
-        id = "new_" .. tostring(vim.loop.hrtime()) .. "_" .. i,
+        id = "new_" .. tostring(vim.uv.hrtime()) .. "_" .. i,
         cell_type = "code",
         source = new_sources[i],
         outputs = {},

--- a/lua/jupynvim/remote_pick.lua
+++ b/lua/jupynvim/remote_pick.lua
@@ -354,7 +354,7 @@ function M.grep(alias, root, pattern, opts)
     -- nearby dirs show within milliseconds even when the full walk of a big
     -- NFS tree takes much longer (snacks' busy spinner shows meanwhile). A
     -- new keystroke supersedes the previous search (backend epoch + sid).
-    local seq = math.floor((vim.uv or vim.loop).hrtime() % 1e9)
+    local seq = math.floor(vim.uv.hrtime() % 1e9)
     local current = { sid = nil, push = nil }
     if not client._search_event_hooked then
       client._search_event_hooked = true

--- a/lua/jupynvim/rpc.lua
+++ b/lua/jupynvim/rpc.lua
@@ -1,10 +1,10 @@
 -- msgpack-rpc client over a child's stdio.
--- Uses vim.loop (libuv) directly so we get raw byte streams (jobstart's line
+-- Uses vim.uv (libuv) directly so we get raw byte streams (jobstart's line
 -- splitting destroys binary msgpack data).
 
 local mpack = vim.mpack
 local log = require("jupynvim.log")
-local uv = vim.loop
+local uv = vim.uv
 
 local M = {}
 


### PR DESCRIPTION
jupynvim requires `nvim v0.11` or higher. This PR replaces the functions deprecated in `v0.10`

-  Use `vim.uv` instead of `vim.loop`
-  Use `vim.bo[buf]` and `nvim_buf_set_option_value` instead of `nvim_buf_set_option`