### PR TITLE
Render external Markdown and HTML images

### DIFF
--- a/lua/jupynvim/init.lua
+++ b/lua/jupynvim/init.lua
@@ -1128,8 +1128,8 @@ function M._attach_autocmds(buf)
         M._ensure_client():call("close", { session_id = nb.session_id }, function() end)
       end
       pcall(function() require("jupynvim.lsp.notebook").on_close(buf) end)
+      if nb then pcall(Image.clear_keys, nb.image_ids or {}) end
       Notebook.remove(buf)
-      pcall(Image.delete_all)
     end,
   })
   -- Refresh borders whenever window dimensions or buffer focus changes —

--- a/lua/jupynvim/notebook/external_image.lua
+++ b/lua/jupynvim/notebook/external_image.lua
@@ -1,0 +1,128 @@
+-- Resolve external Markdown/HTML image references without changing cell source.
+-- HTTP requests run locally through vim.system; relative files are read by the
+-- notebook's existing backend so remote notebooks keep remote filesystem semantics.
+
+local M = {}
+
+local resolved = {}
+local failed = {}
+local inflight = {}
+
+local function finish(key, err, value)
+  if value then resolved[key] = value else failed[key] = err or "image load failed" end
+  local callbacks = inflight[key] or {}
+  inflight[key] = nil
+  vim.schedule(function()
+    for _, callback in ipairs(callbacks) do callback(err, value) end
+  end)
+end
+
+function M.classify(src)
+  if type(src) ~= "string" then return nil end
+  src = vim.trim(src)
+  if src:match("^https?://") then return "http" end
+  if src ~= "" and not src:match("^[%a][%w+.-]*:") and src:sub(1, 1) ~= "/" then
+    return "relative"
+  end
+  return nil
+end
+
+function M.detect_mime(bytes)
+  if type(bytes) ~= "string" then return nil end
+  if bytes:sub(1, 8) == "\137PNG\r\n\26\n" then return "image/png" end
+  if bytes:sub(1, 3) == "\255\216\255" then return "image/jpeg" end
+  return nil
+end
+
+function M.resolve_path(notebook_path, src)
+  if type(notebook_path) ~= "string" or notebook_path == "" then return nil end
+  local dir = vim.fs.dirname(notebook_path)
+  if not dir then return nil end
+  return vim.fs.normalize(vim.fs.joinpath(dir, vim.trim(src)))
+end
+
+local function resolve_http(src, key, opts)
+  local system = opts.system or vim.system
+  system({ "curl", "--location", "--fail", "--silent", "--show-error", src },
+    { text = false }, function(result)
+      if result.code ~= 0 then
+        finish(key, result.stderr or ("HTTP fetch failed: " .. result.code), nil)
+        return
+      end
+      local mime = M.detect_mime(result.stdout)
+      if not mime then
+        finish(key, "unsupported or invalid image", nil)
+        return
+      end
+      finish(key, nil, { b64 = vim.base64.encode(result.stdout), mime = mime })
+    end)
+end
+
+local function resolve_relative(src, key, opts)
+  local path = M.resolve_path(opts.notebook_path, src)
+  if not path then
+    finish(key, "notebook path unavailable", nil)
+    return
+  end
+  if not opts.client or type(opts.client.call) ~= "function" then
+    finish(key, "notebook backend unavailable", nil)
+    return
+  end
+  opts.client:call("fs_read", { path = path }, function(err, result)
+    if err or not result or type(result.content_b64) ~= "string" then
+      finish(key, err or "fs_read returned no image data", nil)
+      return
+    end
+    local ok, bytes = pcall(vim.base64.decode, result.content_b64)
+    local mime = ok and M.detect_mime(bytes) or nil
+    if not mime then
+      finish(key, "unsupported or invalid image", nil)
+      return
+    end
+    finish(key, nil, { b64 = result.content_b64, mime = mime })
+  end)
+end
+
+-- callback(err, { b64, mime }). Concurrent callers for one source share work.
+function M.resolve(src, opts, callback)
+  opts = opts or {}
+  local kind = M.classify(src)
+  if not kind then
+    vim.schedule(function() callback("unsupported image source", nil) end)
+    return
+  end
+  src = vim.trim(src)
+  local key = kind == "http" and src or M.resolve_path(opts.notebook_path, src)
+  if not key then
+    vim.schedule(function() callback("notebook path unavailable", nil) end)
+    return
+  end
+  if resolved[key] then
+    local value = resolved[key]
+    vim.schedule(function() callback(nil, value) end)
+    return
+  end
+  if failed[key] then
+    local err = failed[key]
+    vim.schedule(function() callback(err, nil) end)
+    return
+  end
+  if inflight[key] then
+    table.insert(inflight[key], callback)
+    return
+  end
+  inflight[key] = { callback }
+  if kind == "http" then
+    resolve_http(src, key, opts)
+  else
+    resolve_relative(src, key, opts)
+  end
+end
+
+function M.clear_cache()
+  resolved = {}
+  failed = {}
+  inflight = {}
+end
+
+return M

--- a/lua/jupynvim/notebook/image.lua
+++ b/lua/jupynvim/notebook/image.lua
@@ -779,10 +779,12 @@ end
 -- (~60 bytes each, no image data). A placeholder cell whose image has no
 -- virtual placement falls back to native-size tile mapping, which renders
 -- as a randomly cropped image; this heals that within one refresh.
-function M.reassert_virtual_placements()
-  for _, p in pairs(placements) do
-    -- animated placements self-heal on every frame tick; statics need this
-    if p.renderer == "placeholder" and p.cols and p.rows and not p.timer then
+function M.reassert_virtual_placements(keys)
+  for key, p in pairs(placements) do
+    -- Only heal images owned by the notebook being rendered. Reasserting every
+    -- open notebook's placements can draw a hidden notebook over the active one.
+    if (not keys or keys[key])
+        and p.renderer == "placeholder" and p.cols and p.rows and not p.timer then
       kitty_call_async("kitty_place_virtual", {
         image_id = p.image_id, cols = p.cols, rows = p.rows,
       })
@@ -804,6 +806,10 @@ function M.clear_for_cell(cell_id)
   stop_timer(p)
   kitty_call_async("kitty_clear_image", { image_id = p.image_id })
   placements[cell_id] = nil
+end
+
+function M.clear_keys(keys)
+  for key in pairs(keys or {}) do M.clear_for_cell(key) end
 end
 
 function M.clear_all()

--- a/lua/jupynvim/notebook/markdown.lua
+++ b/lua/jupynvim/notebook/markdown.lua
@@ -198,6 +198,55 @@ local function find_links(line)
 end
 M.find_links = find_links
 
+local function html_attr(tag, name)
+  local pat = "%f[%a]" .. name:gsub(".", function(c)
+    return "[" .. c:lower() .. c:upper() .. "]"
+  end) .. "%f[^%a]%s*=%s*"
+  local start, value = tag:match("()" .. pat .. '"([^"]*)"')
+  if start then return value, start - 1 end
+  start, value = tag:match("()" .. pat .. "'([^']*)'")
+  if start then return value, start - 1 end
+  return nil
+end
+
+-- Discover external Markdown images with the existing balanced-link parser and
+-- the minimum HTML handling needed for <img src="...">. Positions are 0-based
+-- within the cell source, matching Neovim extmark coordinates.
+function M.find_images(source)
+  local images = {}
+  if type(source) ~= "string" then return images end
+  local lnum = 0
+  for line in (source .. "\n"):gmatch("([^\n]*)\n") do
+    for _, link in ipairs(find_links(line)) do
+      if link.start > 1 and line:sub(link.start - 1, link.start - 1) == "!" then
+        table.insert(images, {
+          src = vim.trim(link.url), alt = link.text,
+          lnum = lnum, col = link.start - 2,
+        })
+      end
+    end
+    local lower, cursor = line:lower(), 1
+    while true do
+      local tag_start = lower:find("<img", cursor, true)
+      if not tag_start then break end
+      local tag_end = lower:find(">", tag_start, true)
+      if not tag_end then break end
+      local tag = line:sub(tag_start, tag_end)
+      local src = html_attr(tag, "src")
+      if src then
+        local alt = html_attr(tag, "alt") or ""
+        table.insert(images, {
+          src = vim.trim(src), alt = alt,
+          lnum = lnum, col = tag_start - 1,
+        })
+      end
+      cursor = tag_end + 1
+    end
+    lnum = lnum + 1
+  end
+  return images
+end
+
 -- The link under byte column `col` (1-based) in `line`, or the first link
 -- on the line as a fallback. Used by the gx mapping.
 function M.link_at(line, col)

--- a/lua/jupynvim/notebook/render.lua
+++ b/lua/jupynvim/notebook/render.lua
@@ -347,25 +347,36 @@ local function render_cell(nb, cell, range, geom, win, cellno, selected, editing
     -- on an extmark re-render and can never linger over the gif/image.
     local md_lead = repeat_char(" ", gut)
     local lines_below = {}
+    local external_refs = {}
+    local function append_markdown_image(key)
+      local ph = image.placeholder_virt_lines(key)
+      if ph then
+        for _, line in ipairs(ph) do
+          table.insert(lines_below, { { md_lead, "Normal" }, { line[1][1], line[1][2] } })
+        end
+      else
+        local ascii = image.ascii_lines_for(key)
+        if ascii then
+          for _, line in ipairs(ascii) do
+            table.insert(lines_below, { { md_lead .. line, "Normal" } })
+          end
+        end
+      end
+    end
     if cell.cell_type == "markdown" then
       local Embedded = require("jupynvim.notebook.embedded")
+      local External = require("jupynvim.notebook.external_image")
+      local Markdown = require("jupynvim.notebook.markdown")
       local src = cell.source or ""
       for _, img in ipairs(Embedded.list_images(cell.id) or {}) do
         if src:find("jupynvim%-img:" .. img.idx, 1, false) then
-          local key = cell.id .. "_md_" .. img.idx
-          local ph = image.placeholder_virt_lines(key)
-          if ph then
-            for _, line in ipairs(ph) do
-              table.insert(lines_below, { { md_lead, "Normal" }, { line[1][1], line[1][2] } })
-            end
-          else
-            local ascii = image.ascii_lines_for(key)
-            if ascii then
-              for _, line in ipairs(ascii) do
-                table.insert(lines_below, { { md_lead .. line, "Normal" } })
-              end
-            end
-          end
+          append_markdown_image(cell.id .. "_md_" .. img.idx)
+        end
+      end
+      for _, ref in ipairs(Markdown.find_images(src)) do
+        if External.classify(ref.src) then
+          table.insert(external_refs, ref)
+          append_markdown_image(tostring(nb.buf) .. "_" .. cell.id .. "_external_" .. #external_refs)
         end
       end
     end
@@ -384,8 +395,8 @@ local function render_cell(nb, cell, range, geom, win, cellno, selected, editing
         range.start, math.min(range.stop - 1, total - 1), width)
       local Embedded = require("jupynvim.notebook.embedded")
       local imgs = Embedded.list_images(cell.id)
+      nb.image_ids = nb.image_ids or {}
       if imgs and #imgs > 0 then
-        nb.image_ids = nb.image_ids or {}
         for _, img in ipairs(imgs) do
           local key = cell.id .. "_md_" .. img.idx
           local renderer = (require("jupynvim").config.image_renderer) or "chafa"
@@ -396,6 +407,33 @@ local function render_cell(nb, cell, range, geom, win, cellno, selected, editing
                 vim.schedule(function() M.refresh(nb, win) end)
               end
             end, { renderer = renderer, mime = img.mime })
+          end
+        end
+      end
+      if #external_refs > 0 then
+        local External = require("jupynvim.notebook.external_image")
+        local J = require("jupynvim")
+        nb.pending_external_images = nb.pending_external_images or {}
+        local renderer = (J.config.image_renderer) or "chafa"
+        for idx, ref in ipairs(external_refs) do
+          local key = tostring(nb.buf) .. "_" .. cell.id .. "_external_" .. idx
+          if not nb.image_ids[key] and not nb.pending_external_images[key] then
+            nb.pending_external_images[key] = true
+            local client = External.classify(ref.src) == "relative" and J._nb_client(nb) or nil
+            External.resolve(ref.src, { notebook_path = nb.path, client = client }, function(err, resolved)
+              if err or not resolved then
+                nb.pending_external_images[key] = nil
+                return
+              end
+              if require("jupynvim.notebook").get(nb.buf) ~= nb then return end
+              image.ensure_transmitted(key, resolved.b64, function(id)
+                nb.pending_external_images[key] = nil
+                if id then
+                  nb.image_ids[key] = id
+                  vim.schedule(function() M.refresh(nb, win) end)
+                end
+              end, { renderer = renderer, mime = resolved.mime })
+            end)
           end
         end
       end
@@ -669,7 +707,9 @@ local function do_render(nb, win, opts)
   -- the image. Placements only get lost on layout changes, which refresh
   -- through the normal (non-tick) path.
   if not (opts and (opts.exec_tick or opts.no_image)) then
-    pcall(image.reassert_virtual_placements)
+    local image_keys = {}
+    for key in pairs(nb.image_ids or {}) do image_keys[key] = true end
+    pcall(image.reassert_virtual_placements, image_keys)
   end
 end
 

--- a/tests/external_image_spec.lua
+++ b/tests/external_image_spec.lua
@@ -1,0 +1,96 @@
+-- Headless contracts for external image resolution.
+local here = debug.getinfo(1, "S").source:sub(2)
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(here, ":p:h:h"))
+local External = require("jupynvim.notebook.external_image")
+
+assert(External.classify("http://example.test/a") == "http")
+assert(External.classify("https://example.test/a") == "http")
+assert(External.classify("./images/a.png") == "relative")
+assert(External.classify("../images/a.jpg") == "relative")
+assert(External.classify("data:image/png;base64,x") == nil)
+assert(External.classify("/absolute/a.png") == nil)
+print("1. source classification ok")
+
+local png = "\137PNG\r\n\26\n" .. string.rep("x", 16)
+local jpeg = "\255\216\255\224" .. string.rep("x", 16)
+assert(External.detect_mime(png) == "image/png")
+assert(External.detect_mime(jpeg) == "image/jpeg")
+assert(External.detect_mime("not an image") == nil)
+assert(External.resolve_path("/work/notebooks/a.ipynb", "../assets/a.jpg") == "/work/assets/a.jpg")
+print("2. MIME signatures and notebook-relative paths ok")
+
+local function await(test)
+  assert(vim.wait(1000, test, 5), "timed out waiting for callback")
+end
+
+-- One HTTP process serves concurrent callers; successful result is cached.
+External.clear_cache()
+local starts, system_done = 0, nil
+local function fake_system(argv, opts, done)
+  starts = starts + 1
+  assert(vim.deep_equal(argv, {
+    "curl", "--location", "--fail", "--silent", "--show-error", "https://example.test/image",
+  }), "HTTP argv changed")
+  assert(opts.text == false)
+  system_done = done
+  return {}
+end
+local results = {}
+for i = 1, 2 do
+  External.resolve("https://example.test/image", { system = fake_system }, function(err, value)
+    results[i] = { err = err, value = value }
+  end)
+end
+assert(starts == 1, "duplicate in-flight HTTP request")
+system_done({ code = 0, stdout = png, stderr = "" })
+await(function() return #results == 2 end)
+assert(results[1].value.mime == "image/png" and results[2].value.b64 == results[1].value.b64)
+External.resolve("https://example.test/image", { system = fake_system }, function(err, value)
+  results[3] = { err = err, value = value }
+end)
+await(function() return results[3] ~= nil end)
+assert(starts == 1, "resolved URL did not use session cache")
+print("3. async HTTP in-flight sharing and resolved cache ok")
+
+-- Relative reads cross the notebook backend boundary and preserve JPEG MIME.
+External.clear_cache()
+local called, relative_result
+local client = {
+  call = function(_, method, args, callback)
+    called = { method = method, args = args }
+    callback(nil, { content_b64 = vim.base64.encode(jpeg), size = #jpeg })
+  end,
+}
+External.resolve("./images/photo.jpg", {
+  notebook_path = "/remote/project/notebooks/lesson.ipynb",
+  client = client,
+}, function(err, value)
+  relative_result = { err = err, value = value }
+end)
+await(function() return relative_result ~= nil end)
+assert(called.method == "fs_read")
+assert(called.args.path == "/remote/project/notebooks/images/photo.jpg")
+assert(relative_result.value.mime == "image/jpeg")
+print("4. backend fs_read and JPEG MIME ok")
+
+-- Invalid bytes fail once and remain negatively cached.
+External.clear_cache()
+local invalid_starts, invalid_results = 0, 0
+local function invalid_system(_, _, done)
+  invalid_starts = invalid_starts + 1
+  done({ code = 0, stdout = "html response", stderr = "" })
+  return {}
+end
+for _ = 1, 2 do
+  External.resolve("https://example.test/invalid", { system = invalid_system }, function(err, value)
+    assert(err and value == nil)
+    invalid_results = invalid_results + 1
+  end)
+  await(function() return invalid_results > 0 end)
+end
+await(function() return invalid_results == 2 end)
+assert(invalid_starts == 1, "failed image retried")
+print("5. invalid image rejection and failure cache ok")
+
+print("ALL EXTERNAL-IMAGE CHECKS PASSED")
+vim.cmd("qa!")

--- a/tests/markdown_spec.lua
+++ b/tests/markdown_spec.lua
@@ -20,6 +20,26 @@ assert(MD.link_at("see <https://nvim.io> now", 8).url == "https://nvim.io", "aut
 assert(MD.link_at("at https://x.dev/page ok", 5).url:find("x.dev"), "bare url link_at failed")
 print("2. link_at: link/autolink/bare-url ok")
 
+-- External image discovery reuses balanced Markdown links and minimally parses HTML.
+local image_source = table.concat({
+  "![plot](https://example.test/image.png)",
+  '<img src="https://example.test/a.png">',
+  "<img src='https://example.test/b.jpg'>",
+  '<img src = "./images/c.png">',
+  "<img  src   =   '../images/d.jpg'>",
+  "[ordinary](https://example.test/not-an-image.png)",
+}, "\n")
+local found_images = MD.find_images(image_source)
+assert(#found_images == 5, "expected 5 external images, got " .. #found_images)
+assert(found_images[1].src == "https://example.test/image.png")
+assert(found_images[1].alt == "plot" and found_images[1].lnum == 0 and found_images[1].col == 0)
+assert(found_images[2].src == "https://example.test/a.png")
+assert(found_images[3].src == "https://example.test/b.jpg")
+assert(found_images[4].src == "./images/c.png")
+assert(found_images[5].src == "../images/d.jpg")
+assert(image_source:find('<img src = "./images/c.png">', 1, true), "discovery changed source")
+print("2b. Markdown and HTML image discovery ok")
+
 -- 3. rendered extmarks in a buffer
 local buf = vim.api.nvim_create_buf(true, false)
 local ns = vim.api.nvim_create_namespace("t")

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -102,6 +102,10 @@ md_out=$(nvim --headless -u NONE -c "luafile $ROOT/tests/markdown_spec.lua" -c '
 echo "$md_out" | tail -1
 echo "$md_out" | grep -q "ALL MARKDOWN CHECKS PASSED"
 section "markdown spec" "$?"
+ext_img_out=$(nvim --headless -u NONE -c "luafile $ROOT/tests/external_image_spec.lua" -c 'qa!' 2>&1)
+echo "$ext_img_out" | tail -1
+echo "$ext_img_out" | grep -q "ALL EXTERNAL-IMAGE CHECKS PASSED"
+section "external-image spec" "$?"
 co_out=$(nvim --headless -u NONE -c "luafile $ROOT/tests/cellops_spec.lua" -c 'qa!' 2>&1)
 echo "$co_out" | tail -1
 echo "$co_out" | grep -q "ALL CELL-OPS CHECKS PASSED"


### PR DESCRIPTION
## Summary
- discover external Markdown images with the existing link parser
- discover simple HTML `<img src>` references, including whitespace around `src =`
- resolve HTTP(S) PNG/JPEG asynchronously with an in-memory cache
- resolve notebook-relative PNG/JPEG through the existing backend `fs_read` boundary
- pass resolved bytes and MIME types through the existing placeholder renderer
- isolate image placement state across simultaneously open notebooks

External references remain unchanged in notebook source. This does not add PDF support, external GIF expansion, source-position placement, a renderer, or a runtime dependency.

## Validation
- `tests/external_image_spec.lua`: pass
- `tests/markdown_spec.lua`: pass
- Lua e2e: 25/25 pass
- backend integration: 22/22 pass
- Rust tests: 25/25 pass
- visually verified in Ghostty 1.3.1 with real learner notebooks

## Known test environment issue
`tests/frame_layout.sh` still fails its existing `#8 header or source line not found` screen assertion; no frame-layout code is changed by this PR.