### PR TITLE
Add mode option to keymap overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,8 +366,14 @@ require("jupynvim").setup({
   -- (mode and description preserved), `false` to disable a binding. The
   -- full action list lives in lua/jupynvim/keymaps.lua.
   keymaps = {
-    -- run_advance = "<leader>jr",  -- example: rebind run-and-advance
-    -- move_up = false,             -- example: disable move-cell-up
+    -- example: rebind run-and-advance
+    -- run_advance = "<leader>jr",
+    --
+    -- example: rebind run-and-stay and change mode to NORMAL only
+    -- run_stay = { mode = { "n" }, lhs = "<leader>js" },
+    --
+    -- example: disable move-cell-up
+    -- move_up = false,
   },
 
   -- Skip the entire default keymap set if you want to bind everything yourself.

--- a/lua/jupynvim/notebook/keymaps.lua
+++ b/lua/jupynvim/notebook/keymaps.lua
@@ -98,9 +98,9 @@ local function bind_all(buf, api)
       local mode = def.mode
       if type(override) == "string" then
         lhs = override
-      elseif type(override) == "table" and override.lhs then
-        lhs = override.lhs
-        mode = override.mode
+      elseif type(override) == "table" then
+        if override.lhs then lhs = override.lhs end
+        if override.mode then mode = override.mode end
       end
       local builder = actions[name]
       if builder then

--- a/lua/jupynvim/notebook/keymaps.lua
+++ b/lua/jupynvim/notebook/keymaps.lua
@@ -95,14 +95,16 @@ local function bind_all(buf, api)
       -- skip
     else
       local lhs = def.lhs
+      local mode = def.mode
       if type(override) == "string" then
         lhs = override
       elseif type(override) == "table" and override.lhs then
         lhs = override.lhs
+        mode = override.mode
       end
       local builder = actions[name]
       if builder then
-        vim.keymap.set(def.mode, lhs, builder(buf, api),
+        vim.keymap.set(mode, lhs, builder(buf, api),
           { buffer = buf, silent = true, desc = def.desc })
       end
     end


### PR DESCRIPTION
Related to #30, adds the option to override keymap mode. This will mainly affect the `run_stay` and `run_advance` keymaps, since these are the only ones set for both `NORMAL` and `INSERT` modes. README has been updated to reflect these changes.