### PR TITLE
Fixed inability to decode whitespace characters in base64 image raw text

### DIFF
--- a/lua/jupynvim/init.lua
+++ b/lua/jupynvim/init.lua
@@ -1968,7 +1968,7 @@ function M.save_image(buf, path)
   end
   path = vim.fn.fnamemodify(path, ":p")
 
-  local raw_ok, raw = pcall(vim.base64.decode, b64)
+  local raw_ok, raw = pcall(vim.base64.decode, (b64:gsub("%s", "")))
   if not raw_ok or not raw then
     vim.notify("jupynvim: failed to decode image", vim.log.levels.ERROR)
     return

--- a/lua/jupynvim/notebook/image.lua
+++ b/lua/jupynvim/notebook/image.lua
@@ -605,6 +605,7 @@ function M.animations_paused() return M._anim_paused end
 
 function M.ensure_transmitted(cell_id, b64, callback, opts)
   opts = opts or {}
+  b64 = (b64 or ""):gsub("%s", "")
   local renderer = opts.renderer or "chafa"
   local mime = opts.mime
   local h = quick_hash(b64)


### PR DESCRIPTION
Image base64 encoding previously broke when there were whitespace characters. This fix makes saving and rendering images strips the whitespace characters before passing it into the Rust backend.